### PR TITLE
Add pagination to crafts listing and update view

### DIFF
--- a/eCommerceProject/Controllers/CraftController.cs
+++ b/eCommerceProject/Controllers/CraftController.cs
@@ -14,16 +14,25 @@ public class CraftController : Controller
         _context = context;
     }
     /// <summary>
-    /// Shows all crafts using asyncronous code
+    /// Shows all crafts using asyncronous code. 
     /// </summary>
+    /// <param name="id">Page Number</param>
     /// <returns></returns>
     [HttpGet]
-    public async Task<IActionResult> Index()
+    public async Task<IActionResult> Index(int? id)
     {
-        // Get all crafts from Db
-        List<Craft> crafts = await _context.Crafts.ToListAsync();
+        const int NumCraftsToShowPerPage = 3;
+        const int PageOffset = 1;
+        // If id is null, set currentPage to 1, otherwise set it to id
+        // If (id.HasValue) is true, currentPage = id.Value, otherwise currentPage = 1
+        int currentPage = id ?? 1; // Null Coalescing Operator
+
+        // Get all crafts from Db using LINQ query
+        List<Craft> crafts = await _context.Crafts
+                            .Skip(NumCraftsToShowPerPage * (currentPage - PageOffset))
+                            .Take(NumCraftsToShowPerPage)
+                            .ToListAsync();
         // Show them on page
-        //return View(_context.Crafts.ToList());
         return View(crafts);
     }
 

--- a/eCommerceProject/Views/Craft/Index.cshtml
+++ b/eCommerceProject/Views/Craft/Index.cshtml
@@ -23,45 +23,54 @@
     <a asp-action="Create" asp-controller="Craft">Create a Craft</a>
 </p>
 
-<table class="table table-striped table-hover">
-    <thead>
-        <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.CraftId)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Title)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Price)
-            </th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (Craft item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.CraftId)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Title)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Price)
-            </td>
-            <td>
-                    @* Newer Syntax *@
-                <a class="btn btn-primary" asp-action="Edit" asp-route-id="@item.CraftId">Edit</a>
-                <a class="btn btn-secondary" asp-action="Details" asp-route-id="@item.CraftId">Details</a>
-                <a class="btn btn-danger" asp-action="Delete" asp-route-id="@item.CraftId">Delete</a>
+@if (Model.Count() == 0)
+{
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th>
+                    @Html.DisplayNameFor(model => model.CraftId)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Title)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Price)
+                </th>
+                <th></th>
+            </tr>
+        </thead>
+
+        <tbody>
+        @foreach (Craft item in Model) 
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.CraftId)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Title)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Price)
+                </td>
+                <td>
+                        @* Newer Syntax *@
+                    <a class="btn btn-primary" asp-action="Edit" asp-route-id="@item.CraftId">Edit</a>
+                    <a class="btn btn-secondary" asp-action="Details" asp-route-id="@item.CraftId">Details</a>
+                    <a class="btn btn-danger" asp-action="Delete" asp-route-id="@item.CraftId">Delete</a>
    
-                @* Older Syntax*@
-                @* @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) | *@
-                @* @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ }) | *@
-                @* @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ }) *@
-            </td>
-        </tr>
-    }
-    </tbody>
-</table>
+                    @* Older Syntax*@
+                    @* @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) | *@
+                    @* @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ }) | *@
+                    @* @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ }) *@
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+else
+{
+    <h2>There are no crafts for this page.</h2>
+}


### PR DESCRIPTION
Updated `CraftController` to support pagination in the `Index` method, allowing for an optional `id` parameter to specify the current page. The method retrieves 3 crafts per page using LINQ's `Skip` and `Take` methods.

Modified `Index.cshtml` to include a conditional display for empty craft lists and implemented a new table structure for displaying crafts with their `CraftId`, `Title`, and `Price`. Transitioned to newer syntax for action links.

Closes #18 